### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI/CD Pipeline
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/Sudan-Digital-Archive/api/security/code-scanning/1](https://github.com/Sudan-Digital-Archive/api/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block in the workflow (either at the top level so it applies to all jobs by default, or inside each job) and set it to the minimal scope required. For this CI/CD workflow, all operations that modify remote state are aimed at DigitalOcean (via `doctl`) and Docker registry, not GitHub. The GitHub-specific operations are source checkout and caching, which work with a read-only `contents` permission. Therefore, the least-privilege fix is to add `permissions: contents: read` at the workflow (root) level so the `GITHUB_TOKEN` cannot write to the repository.

Concretely, in `.github/workflows/ci.yml`, add a `permissions:` block right after the `name: CI/CD Pipeline` line (before `on:`). This defines default permissions for all jobs, including `build-and-test`, without altering any job steps or behavior. No additional imports, methods, or definitions are required; this is a pure YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
