### PR TITLE
feat: redesign wacz/media upload to use presigned S3 URLs (#133)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -328,9 +328,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
-version = "1.8.15"
+version = "1.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11493b0bad143270fb8ad284a096dd529ba91924c5409adeac856cc1bf047dbc"
+checksum = "50f156acdd2cf55f5aa53ee416c4ac851cf1222694506c0b1f78c85695e9ca9d"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -370,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -380,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -392,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.2"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc0651c57e384202e47153c1260b84a9936e19803d747615edf199dc3b98d17"
+checksum = "5dcd93c82209ac7413532388067dce79be5a8780c1786e5fae3df22e4dee2864"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -440,23 +440,23 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
  "lru",
  "percent-encoding",
  "regex-lite",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.97.0"
+version = "1.98.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aadc669e184501caaa6beafb28c6267fc1baef0810fb58f9b205485ca3f2567"
+checksum = "d69c77aafa20460c68b6b3213c84f6423b6e76dbf89accd3e1789a686ffd9489"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -478,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.99.0"
+version = "1.100.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1342a7db8f358d3de0aed2007a0b54e875458e39848d54cc1d46700b2bfcb0a8"
+checksum = "1c7e7b09346d5ca22a2a08267555843a6a0127fb20d8964cb6ecfb8fdb190225"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -502,9 +502,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.101.0"
+version = "1.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab41ad64e4051ecabeea802d6a17845a91e83287e1dd249e6963ea1ba78c428a"
+checksum = "c2249b81a2e73a8027c41c378463a81ec39b8510f184f2caab87de912af0f49b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -527,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b660013a6683ab23797778e21f1f854744fdf05f68204b4cca4c8c04b5d1f4"
+checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -540,13 +540,13 @@ dependencies = [
  "crypto-bigint 0.5.5",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.13.0",
  "http 0.2.12",
  "http 1.4.0",
  "p256 0.11.1",
  "percent-encoding",
  "ring",
- "sha2",
+ "sha2 0.11.0",
  "subtle",
  "time",
  "tracing",
@@ -580,7 +580,7 @@ dependencies = [
  "md-5",
  "pin-project-lite",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "tracing",
 ]
 
@@ -655,11 +655,11 @@ dependencies = [
  "hyper 0.14.32",
  "hyper 1.9.0",
  "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.7",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
@@ -707,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.10.3"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028999056d2d2fd58a697232f9eec4a643cf73a71cf327690a7edad1d2af2110"
+checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http 0.63.6",
@@ -732,11 +732,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.11.6"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ab3c9c29791ba4ba02b780a3049e21ec63dabda09268b175272c3733a79e6"
+checksum = "b71a13df6ada0aafbf21a73bdfcdf9324cfa9df77d96b8446045be3cde61b42e"
 dependencies = [
  "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
@@ -745,6 +746,17 @@ dependencies = [
  "tokio",
  "tracing",
  "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -784,9 +796,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.14"
+version = "1.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c8323699dd9b3c8d5b3c13051ae9cdef58fd179957c882f8374dd8725962d9"
+checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -798,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "axum-macros",
@@ -879,9 +891,9 @@ dependencies = [
 
 [[package]]
 name = "axum-macros"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
+checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -938,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
@@ -964,6 +976,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1076,9 +1097,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1114,9 +1135,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1136,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -1162,6 +1183,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1169,9 +1196,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
  "brotli",
  "compression-core",
@@ -1183,9 +1210,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -1201,6 +1228,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "cookie"
@@ -1249,6 +1282,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1259,9 +1301,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc-fast"
@@ -1270,8 +1312,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3"
 dependencies = [
  "crc",
- "digest",
- "rand 0.9.2",
+ "digest 0.10.7",
+ "rand 0.9.4",
  "regex",
  "rustversion",
 ]
@@ -1335,15 +1377,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1416,7 +1476,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "zeroize",
 ]
 
@@ -1426,7 +1486,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1486,10 +1546,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -1534,7 +1606,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der 0.7.10",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve 0.13.8",
  "rfc6979 0.4.0",
  "signature 2.2.0",
@@ -1560,7 +1632,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -1583,7 +1655,7 @@ dependencies = [
  "base16ct 0.1.1",
  "crypto-bigint 0.4.9",
  "der 0.6.1",
- "digest",
+ "digest 0.10.7",
  "ff 0.12.1",
  "generic-array",
  "group 0.12.1",
@@ -1602,7 +1674,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct 0.2.0",
  "crypto-bigint 0.5.5",
- "digest",
+ "digest 0.10.7",
  "ff 0.13.1",
  "generic-array",
  "group 0.13.0",
@@ -1689,9 +1761,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
@@ -2009,7 +2081,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand 0.9.2",
+ "rand 0.9.4",
  "smallvec",
  "spinning_top",
  "web-time",
@@ -2103,9 +2175,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -2170,7 +2242,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -2179,7 +2251,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2259,6 +2340,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2321,16 +2411,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.0",
  "hyper 1.9.0",
  "hyper-util",
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
@@ -2509,9 +2598,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2519,12 +2608,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -2580,9 +2669,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2599,16 +2688,16 @@ dependencies = [
  "base64",
  "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac",
+ "hmac 0.12.1",
  "js-sys",
  "p256 0.13.2",
  "p384",
  "pem",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "signature 2.2.0",
  "simple_asn1",
 ]
@@ -2639,9 +2728,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -2651,14 +2740,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2749,7 +2838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2907,7 +2996,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -2962,9 +3051,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2994,9 +3083,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -3051,7 +3140,7 @@ checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
 dependencies = [
  "ecdsa 0.14.8",
  "elliptic-curve 0.12.3",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3063,7 +3152,7 @@ dependencies = [
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3075,7 +3164,7 @@ dependencies = [
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3223,9 +3312,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -3406,7 +3495,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
@@ -3423,10 +3512,10 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -3478,9 +3567,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3489,9 +3578,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3555,9 +3644,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]
@@ -3623,7 +3712,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
- "hyper-rustls 0.27.7",
+ "hyper-rustls 0.27.9",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -3633,7 +3722,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3661,7 +3750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
  "crypto-bigint 0.4.9",
- "hmac",
+ "hmac 0.12.1",
  "zeroize",
 ]
 
@@ -3671,7 +3760,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -3724,8 +3813,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -3768,7 +3857,7 @@ version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
  "walkdir",
 ]
 
@@ -3782,7 +3871,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",
@@ -3831,15 +3920,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -3858,9 +3947,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -3878,9 +3967,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4172,9 +4261,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -4262,8 +4351,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4273,8 +4362,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -4308,7 +4408,7 @@ version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -4318,7 +4418,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -4461,7 +4561,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "time",
@@ -4500,7 +4600,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -4524,7 +4624,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -4534,19 +4634,19 @@ dependencies = [
  "generic-array",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "itoa",
  "log",
  "md-5",
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "rust_decimal",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -4577,7 +4677,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",
@@ -4585,11 +4685,11 @@ dependencies = [
  "memchr",
  "num-bigint",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rust_decimal",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -4690,13 +4790,13 @@ dependencies = [
  "mime",
  "once_cell",
  "pretty_assertions",
- "rand 0.8.5",
+ "rand 0.8.6",
  "reqwest",
  "sea-orm",
  "sea-orm-codegen",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tokio",
  "tower",
  "tower-http",
@@ -4899,9 +4999,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -4915,9 +5015,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4950,7 +5050,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls 0.23.40",
  "tokio",
 ]
 
@@ -4989,9 +5089,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.9+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da053d28fe57e2c9d21b48261e14e7b4c8b670b54d2c684847b91feaf4c7dac5"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -5001,9 +5101,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ca317ebc49f06bd748bfba29533eac9485569dc9bf80b849024b025e814fb9"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
@@ -5146,9 +5246,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicase"
@@ -5284,9 +5384,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -5381,11 +5481,11 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -5394,7 +5494,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -5405,9 +5505,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5419,9 +5519,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5429,9 +5529,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5439,9 +5539,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5452,9 +5552,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -5508,9 +5608,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5528,9 +5628,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5870,9 +5970,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -5885,6 +5985,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -5967,9 +6073,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,7 @@ pub struct AppConfig {
     pub digital_ocean_spaces_access_key: String,
     pub digital_ocean_spaces_secret_key: String,
     pub max_file_upload_size: usize,
+    pub presigned_put_url_expiry_seconds: u64,
     pub s3_operation_timeout: u64,
     pub s3_operation_attempt_timeout: u64,
     pub s3_connect_timeout: u64,
@@ -91,6 +92,10 @@ pub fn build_app_config() -> AppConfig {
     let digital_ocean_spaces_secret_key =
         env::var("DO_SPACES_SECRET_KEY").expect("Missing DO_SPACES_SECRET_KEY env var");
     let max_file_upload_size = 200 * 1024 * 1024;
+    let presigned_put_url_expiry_seconds = env::var("PRESIGNED_PUT_URL_EXPIRY_SECONDS")
+        .expect("Missing PRESIGNED_PUT_URL_EXPIRY_SECONDS env var")
+        .parse()
+        .expect("PRESIGNED_PUT_URL_EXPIRY_SECONDS should be a number");
     let s3_operation_timeout = env::var("S3_OPERATION_TIMEOUT")
         .unwrap_or("30".to_string())
         .parse()
@@ -123,6 +128,7 @@ pub fn build_app_config() -> AppConfig {
         digital_ocean_spaces_access_key,
         digital_ocean_spaces_secret_key,
         max_file_upload_size,
+        presigned_put_url_expiry_seconds,
         s3_operation_timeout,
         s3_operation_attempt_timeout,
         s3_connect_timeout,

--- a/src/main.rs
+++ b/src/main.rs
@@ -127,6 +127,7 @@ async fn main() {
         locations_service: locations_service.clone(),
         creators_service: creators_service.clone(),
         contributors_service: contributors_service.clone(),
+        presigned_put_url_expiry_seconds: app_config.presigned_put_url_expiry_seconds,
     };
     let auth_service = AuthService {
         auth_repo: Arc::new(auth_repo),

--- a/src/models/request.rs
+++ b/src/models/request.rs
@@ -68,20 +68,6 @@ pub struct CreateAccessionRequestRaw {
     pub metadata_contributor_role_ids: Vec<Option<i32>>,
 }
 
-/// Request for creating a new accession from raw file + metadata via multipart upload.
-/// The `metadata` field must be the first part and contain the JSON metadata.
-/// The `file` field must be the second part and contain the file content.
-#[allow(dead_code)]
-#[derive(ToSchema)]
-pub struct CreateAccessionRawMultipartRequest {
-    /// The metadata JSON object.
-    #[schema(value_type = CreateAccessionRequestRaw)]
-    pub metadata: CreateAccessionRequestRaw,
-    /// The file to upload.
-    #[schema(value_type = String, format = Binary)]
-    pub file: Vec<u8>,
-}
-
 /// Request for initiating a new Browsertrix crawl.
 #[derive(Debug, Validate, Deserialize, ToSchema)]
 pub struct CreateCrawlRequest {

--- a/src/models/response.rs
+++ b/src/models/response.rs
@@ -192,6 +192,13 @@ pub struct ListAccessionsResponse {
     pub per_page: u64,
 }
 
+/// Response for initiating a raw file upload.
+#[derive(Debug, Deserialize, Serialize, ToSchema)]
+pub struct InitiateUploadResponse {
+    pub accession_id: i32,
+    pub upload_url: String,
+}
+
 /// Response containing a single subject with its identifier.
 #[derive(Debug, Deserialize, Serialize, ToSchema)]
 pub struct SubjectResponse {

--- a/src/repos/s3_repo.rs
+++ b/src/repos/s3_repo.rs
@@ -67,6 +67,26 @@ pub trait S3Repo: Send + Sync {
         expires_in: u64,
     ) -> Result<String, Box<dyn Error>>;
 
+    /// Generates a presigned URL for PUTting an object to S3.
+    ///
+    /// # Arguments
+    /// * `object_key` - The key (path) of the object in the S3 bucket
+    /// * `expires_in` - Duration in seconds until the presigned URL expires
+    ///
+    /// # Returns
+    /// A presigned URL that can be used to upload the object for the specified duration
+    ///
+    /// # Errors
+    /// Returns Error if:
+    /// * The presigning configuration fails
+    /// * The presigned URL generation fails
+    /// * The expiration time is invalid
+    async fn generate_presigned_put_url(
+        &self,
+        object_key: &str,
+        expires_in: u64,
+    ) -> Result<String, Box<dyn Error>>;
+
     /// Initiates a multipart upload to S3.
     ///
     /// # Arguments
@@ -274,6 +294,42 @@ impl S3Repo for DigitalOceanSpacesRepo {
             )
             .await
             .map_err(|e| format!("Failed to generate presigned URL: {e}"))?;
+
+        Ok(presigned_request.uri().to_string())
+    }
+
+    /// Generates a presigned URL for PUTting an object to S3.
+    ///
+    /// # Arguments
+    /// * `object_key` - The key (path) of the object in the S3 bucket
+    /// * `expires_in` - Duration in seconds until the presigned URL expires
+    ///
+    /// # Returns
+    /// A presigned URL that can be used to upload the object for the specified duration
+    ///
+    /// # Errors
+    /// Returns Error if:
+    /// * The presigning configuration fails
+    /// * The presigned URL generation fails
+    /// * The expiration time is invalid
+    async fn generate_presigned_put_url(
+        &self,
+        object_key: &str,
+        expires_in: u64,
+    ) -> Result<String, Box<dyn Error>> {
+        let expires_in = std::time::Duration::from_secs(expires_in);
+
+        let presigning_config = PresigningConfig::expires_in(expires_in)
+            .map_err(|e| format!("Failed to create presigning config: {e}"))?;
+
+        let presigned_request = self
+            .client
+            .put_object()
+            .bucket(&self.bucket)
+            .key(object_key)
+            .presigned(presigning_config)
+            .await
+            .map_err(|e| format!("Failed to generate presigned PUT URL: {e}"))?;
 
         Ok(presigned_request.uri().to_string())
     }

--- a/src/routes/accessions.rs
+++ b/src/routes/accessions.rs
@@ -7,15 +7,15 @@ use crate::app_factory::AppState;
 use crate::auth::{validate_at_least_contributor, validate_at_least_researcher};
 use crate::models::auth::AuthenticatedUser;
 use crate::models::request::{
-    AccessionPagination, AccessionPaginationWithPrivate, CreateAccessionRawMultipartRequest,
-    CreateAccessionRequest, UpdateAccessionRequest,
+    AccessionPagination, AccessionPaginationWithPrivate,
+    CreateAccessionRequest, CreateAccessionRequestRaw, UpdateAccessionRequest,
 };
 use crate::models::response::{
     GetOneAccessionResponse, InitiateUploadResponse, ListAccessionsResponse,
 };
 use crate::services::accessions_service::MetadataValidationParams;
 use ::entity::sea_orm_active_enums::Role;
-use axum::extract::{DefaultBodyLimit, Multipart, Path, State};
+use axum::extract::{DefaultBodyLimit, Path, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, post, put};
@@ -47,11 +47,7 @@ pub fn get_accessions_routes(max_file_upload_size: usize) -> Router<AppState> {
     post,
     path = "/api/v1/accessions/raw",
     tag = "Accessions",
-    request_body(
-        content = CreateAccessionRawMultipartRequest,
-        content_type = "multipart/form-data",
-        description = "Multipart upload request. \n\n**Important:** The `metadata` field MUST be the first part of the form and contain the JSON metadata. Do NOT include a file field - you will receive a presigned URL to upload directly to S3."
-    ),
+    request_body = CreateAccessionRequestRaw,
     responses(
         (status = 201, description = "Accession created, returns presigned URL for direct S3 upload", body = InitiateUploadResponse),
         (status = 400, description = "Bad request"),
@@ -63,30 +59,38 @@ pub fn get_accessions_routes(max_file_upload_size: usize) -> Router<AppState> {
         ("api_key_auth" = [])
     )
 )]
-#[axum::debug_handler]
 async fn create_accession_raw(
     State(state): State<AppState>,
     authenticated_user: AuthenticatedUser,
-    multipart: Multipart,
+    Json(payload): Json<CreateAccessionRequestRaw>,
 ) -> Response {
     if !validate_at_least_contributor(&authenticated_user.role) {
         return (StatusCode::FORBIDDEN, "Must have at least contributor role").into_response();
     }
-    info!("Received raw accession creation request via multipart/form-data");
-    let create_accession_raw_request = match state
+    info!("Received raw accession creation request via JSON");
+    if let Err(err) = payload.validate() {
+        return (StatusCode::BAD_REQUEST, err.to_string()).into_response();
+    }
+    if let Err(response) = state
         .accessions_service
         .clone()
-        .extract_accession_metadata_from_multipart(multipart)
+        .validate_metadata_references(MetadataValidationParams {
+            subjects: payload.metadata_subjects.clone(),
+            metadata_language: payload.metadata_language,
+            metadata_location_id: payload.metadata_location_id,
+            metadata_creator_id: payload.metadata_creator_id,
+            metadata_contributor_ids: payload.metadata_contributor_ids.clone(),
+            metadata_contributor_role_ids: payload.metadata_contributor_role_ids.clone(),
+        })
         .await
     {
-        Ok(data) => data,
-        Err(response) => return response,
-    };
+        return response;
+    }
 
     state
         .accessions_service
         .clone()
-        .initiate_raw_upload(create_accession_raw_request)
+        .initiate_raw_upload(payload)
         .await
 }
 

--- a/src/routes/accessions.rs
+++ b/src/routes/accessions.rs
@@ -10,7 +10,9 @@ use crate::models::request::{
     AccessionPagination, AccessionPaginationWithPrivate, CreateAccessionRawMultipartRequest,
     CreateAccessionRequest, UpdateAccessionRequest,
 };
-use crate::models::response::{GetOneAccessionResponse, ListAccessionsResponse};
+use crate::models::response::{
+    GetOneAccessionResponse, InitiateUploadResponse, ListAccessionsResponse,
+};
 use crate::services::accessions_service::MetadataValidationParams;
 use ::entity::sea_orm_active_enums::Role;
 use axum::extract::{DefaultBodyLimit, Multipart, Path, State};
@@ -19,7 +21,7 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, post, put};
 use axum::{Json, Router};
 use axum_extra::extract::Query;
-use tracing::{error, info};
+use tracing::info;
 use validator::Validate;
 
 /// Creates routes for accession-related endpoints under `/accessions`.
@@ -48,18 +50,20 @@ pub fn get_accessions_routes(max_file_upload_size: usize) -> Router<AppState> {
     request_body(
         content = CreateAccessionRawMultipartRequest,
         content_type = "multipart/form-data",
-        description = "Multipart upload request. \n\n**Important:** The `metadata` field MUST be the first part of the form and contain the JSON metadata. The `file` field MUST be the second part and contain the binary file content."
+        description = "Multipart upload request. \n\n**Important:** The `metadata` field MUST be the first part of the form and contain the JSON metadata. Do NOT include a file field - you will receive a presigned URL to upload directly to S3."
     ),
     responses(
-        (status = 201, description = "Accession created!"),
+        (status = 201, description = "Accession created, returns presigned URL for direct S3 upload", body = InitiateUploadResponse),
         (status = 400, description = "Bad request"),
-        (status = 403, description = "Forbidden")
+        (status = 403, description = "Forbidden"),
+        (status = 503, description = "S3 service unavailable")
     ),
     security(
         ("jwt_cookie_auth" = []),
         ("api_key_auth" = [])
     )
 )]
+#[axum::debug_handler]
 async fn create_accession_raw(
     State(state): State<AppState>,
     authenticated_user: AuthenticatedUser,
@@ -72,32 +76,18 @@ async fn create_accession_raw(
     let create_accession_raw_request = match state
         .accessions_service
         .clone()
-        .extract_accession_from_multipart_form(multipart)
+        .extract_accession_metadata_from_multipart(multipart)
         .await
     {
         Ok(data) => data,
         Err(response) => return response,
     };
 
-    match state
+    state
         .accessions_service
         .clone()
-        .write_one_raw(create_accession_raw_request)
+        .initiate_raw_upload(create_accession_raw_request)
         .await
-    {
-        Ok(id) => {
-            info!("Raw accession created with id: {}", id);
-            (
-                StatusCode::CREATED,
-                format!("Accession created with id: {id}"),
-            )
-                .into_response()
-        }
-        Err(err) => {
-            error!("Failed to create raw accession: {:?}", err);
-            err
-        }
-    }
 }
 
 #[utoipa::path(
@@ -340,7 +330,9 @@ async fn update_accession(
 mod tests {
     use crate::models::common::MetadataLanguage;
     use crate::models::request::CreateAccessionRequest;
-    use crate::models::response::{GetOneAccessionResponse, ListAccessionsResponse};
+    use crate::models::response::{
+        GetOneAccessionResponse, InitiateUploadResponse, ListAccessionsResponse,
+    };
     use crate::test_tools::{
         build_test_accessions_service, build_test_app, get_mock_jwt,
         mock_one_accession_with_metadata, mock_paginated_ar, mock_paginated_en,
@@ -373,23 +365,27 @@ mod tests {
             metadata_json = metadata_json.to_string()
         );
 
-        let file_part_header = format!(
-            "--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"{file_name}\"\r\nContent-Type: {file_content_type}\r\n\r\n",
-            boundary = boundary,
-            file_name = file_name,
-            file_content_type = file_content_type
-        );
-        let file_part_footer = "\r\n";
+        if !file_name.is_empty() {
+            let file_part_header = format!(
+                "--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"{file_name}\"\r\nContent-Type: {file_content_type}\r\n\r\n",
+                boundary = boundary,
+                file_name = file_name,
+                file_content_type = file_content_type
+            );
+            let file_part_footer = "\r\n";
 
-        if metadata_first {
-            form_body_parts.push(Bytes::from(metadata_part.into_bytes()));
-            form_body_parts.push(Bytes::from(file_part_header.into_bytes()));
-            form_body_parts.push(Bytes::from(file_bytes));
-            form_body_parts.push(Bytes::from(file_part_footer.as_bytes()));
+            if metadata_first {
+                form_body_parts.push(Bytes::from(metadata_part.into_bytes()));
+                form_body_parts.push(Bytes::from(file_part_header.into_bytes()));
+                form_body_parts.push(Bytes::from(file_bytes));
+                form_body_parts.push(Bytes::from(file_part_footer.as_bytes()));
+            } else {
+                form_body_parts.push(Bytes::from(file_part_header.into_bytes()));
+                form_body_parts.push(Bytes::from(file_bytes));
+                form_body_parts.push(Bytes::from(file_part_footer.as_bytes()));
+                form_body_parts.push(Bytes::from(metadata_part.into_bytes()));
+            }
         } else {
-            form_body_parts.push(Bytes::from(file_part_header.into_bytes()));
-            form_body_parts.push(Bytes::from(file_bytes));
-            form_body_parts.push(Bytes::from(file_part_footer.as_bytes()));
             form_body_parts.push(Bytes::from(metadata_part.into_bytes()));
         }
 
@@ -889,15 +885,7 @@ mod tests {
             "original_url": "https://coolurl.com",
             "s3_filename": "test-small.wacz"
         });
-        let file_bytes = vec![0; 1024 * 1024]; // 1MB file
-        let body = build_multipart_form_data(
-            metadata,
-            file_bytes,
-            "small-file.wacz",
-            "application/wacz",
-            true,
-        )
-        .await;
+        let body = build_multipart_form_data(metadata, vec![], "", "", true).await;
 
         let response = app
             .oneshot(
@@ -917,8 +905,9 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::CREATED);
         let body = response.into_body().collect().await.unwrap().to_bytes();
-        let actual = String::from_utf8((&body).to_vec()).unwrap();
-        assert_eq!(actual, "Accession created with id: 10");
+        let actual: InitiateUploadResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(actual.accession_id, 10);
+        assert!(actual.upload_url.contains("mock-presigned-put-url"));
     }
 
     #[tokio::test]
@@ -935,15 +924,7 @@ mod tests {
             "original_url": "https://coolurl.com",
             "s3_filename": "test-large.wacz"
         });
-        let file_bytes = vec![0; 6 * 1024 * 1024]; // 6MB file
-        let body = build_multipart_form_data(
-            metadata,
-            file_bytes,
-            "large-file.wacz",
-            "application/wacz",
-            true,
-        )
-        .await;
+        let body = build_multipart_form_data(metadata, vec![], "", "", true).await;
 
         let response = app
             .oneshot(
@@ -963,54 +944,9 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::CREATED);
         let body = response.into_body().collect().await.unwrap().to_bytes();
-        let actual = String::from_utf8((&body).to_vec()).unwrap();
-        assert_eq!(actual, "Accession created with id: 10");
-    }
-
-    #[tokio::test]
-    async fn create_accession_raw_metadata_order_invalid() {
-        let app = build_test_app();
-        let metadata = json!({
-            "metadata_language": "english",
-            "metadata_title": "Test Metadata Order",
-            "metadata_description": "Metadata order description",
-            "metadata_time": "2024-01-01T00:00:00",
-            "metadata_subjects": [1],
-            "is_private": false,
-            "metadata_format": "wacz",
-            "original_url": "https://coolurl.com",
-            "s3_filename": "test-order-invalid.wacz"
-        });
-        let file_bytes = vec![0; 100]; // 100 bytes file
-        let body = build_multipart_form_data(
-            metadata,
-            file_bytes,
-            "order-invalid-file.wacz",
-            "application/wacz",
-            false,
-        )
-        .await; // metadata_first = false
-
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .method(http::Method::POST)
-                    .uri("/api/v1/accessions/raw")
-                    .header(
-                        http::header::CONTENT_TYPE,
-                        "multipart/form-data; boundary=------------------------abcdef1234567890",
-                    )
-                    .header(http::header::COOKIE, format!("jwt={}", get_mock_jwt()))
-                    .body(body)
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        let body = response.into_body().collect().await.unwrap().to_bytes();
-        let actual = String::from_utf8((&body).to_vec()).unwrap();
-        assert_eq!(actual, "Metadata field should be the first form field");
+        let actual: InitiateUploadResponse = serde_json::from_slice(&body).unwrap();
+        assert_eq!(actual.accession_id, 10);
+        assert!(actual.upload_url.contains("mock-presigned-put-url"));
     }
 
     #[tokio::test]

--- a/src/routes/accessions.rs
+++ b/src/routes/accessions.rs
@@ -7,8 +7,8 @@ use crate::app_factory::AppState;
 use crate::auth::{validate_at_least_contributor, validate_at_least_researcher};
 use crate::models::auth::AuthenticatedUser;
 use crate::models::request::{
-    AccessionPagination, AccessionPaginationWithPrivate,
-    CreateAccessionRequest, CreateAccessionRequestRaw, UpdateAccessionRequest,
+    AccessionPagination, AccessionPaginationWithPrivate, CreateAccessionRequest,
+    CreateAccessionRequestRaw, UpdateAccessionRequest,
 };
 use crate::models::response::{
     GetOneAccessionResponse, InitiateUploadResponse, ListAccessionsResponse,
@@ -311,21 +311,6 @@ async fn update_accession(
     if !validate_at_least_researcher(&authenticated_user.role) {
         return (StatusCode::FORBIDDEN, "Must have at least researcher role").into_response();
     }
-    if let Err(response) = state
-        .accessions_service
-        .clone()
-        .validate_metadata_references(MetadataValidationParams {
-            subjects: payload.metadata_subjects.clone(),
-            metadata_language: payload.metadata_language,
-            metadata_location_id: payload.metadata_location_id,
-            metadata_creator_id: payload.metadata_creator_id,
-            metadata_contributor_ids: payload.metadata_contributor_ids.clone(),
-            metadata_contributor_role_ids: payload.metadata_contributor_role_ids.clone(),
-        })
-        .await
-    {
-        return response;
-    }
 
     state.accessions_service.update_one(id, payload).await
 }
@@ -345,58 +330,12 @@ mod tests {
         body::Body,
         http::{Request, StatusCode},
     };
-    use bytes::Bytes;
     use entity::sea_orm_active_enums::DublinMetadataFormat;
     use http_body_util::BodyExt;
     use pretty_assertions::assert_eq;
     use serde_json::json;
     use tower::ServiceExt;
     use uuid::Uuid;
-
-    async fn build_multipart_form_data(
-        metadata_json: serde_json::Value,
-        file_bytes: Vec<u8>,
-        file_name: &str,
-        file_content_type: &str,
-        metadata_first: bool,
-    ) -> Body {
-        let boundary = "------------------------abcdef1234567890";
-        let mut form_body_parts: Vec<Bytes> = Vec::new();
-
-        let metadata_part = format!(
-            "--{boundary}\r\nContent-Disposition: form-data; name=\"metadata\"\r\nContent-Type: application/json\r\n\r\n{metadata_json}\r\n",
-            boundary = boundary,
-            metadata_json = metadata_json.to_string()
-        );
-
-        if !file_name.is_empty() {
-            let file_part_header = format!(
-                "--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"{file_name}\"\r\nContent-Type: {file_content_type}\r\n\r\n",
-                boundary = boundary,
-                file_name = file_name,
-                file_content_type = file_content_type
-            );
-            let file_part_footer = "\r\n";
-
-            if metadata_first {
-                form_body_parts.push(Bytes::from(metadata_part.into_bytes()));
-                form_body_parts.push(Bytes::from(file_part_header.into_bytes()));
-                form_body_parts.push(Bytes::from(file_bytes));
-                form_body_parts.push(Bytes::from(file_part_footer.as_bytes()));
-            } else {
-                form_body_parts.push(Bytes::from(file_part_header.into_bytes()));
-                form_body_parts.push(Bytes::from(file_bytes));
-                form_body_parts.push(Bytes::from(file_part_footer.as_bytes()));
-                form_body_parts.push(Bytes::from(metadata_part.into_bytes()));
-            }
-        } else {
-            form_body_parts.push(Bytes::from(metadata_part.into_bytes()));
-        }
-
-        form_body_parts.push(Bytes::from(format!("--{}--\r\n", boundary).into_bytes()));
-
-        Body::from(form_body_parts.concat())
-    }
 
     #[tokio::test]
     async fn run_one_crawl() {
@@ -847,26 +786,14 @@ mod tests {
             "original_url": "https://coolurl.com",
             "s3_filename": "test-no-auth.wacz"
         });
-        let file_bytes = vec![0; 100]; // 100 bytes file
-        let body = build_multipart_form_data(
-            metadata,
-            file_bytes,
-            "test-file.wacz",
-            "application/wacz",
-            true,
-        )
-        .await;
 
         let response = app
             .oneshot(
                 Request::builder()
                     .method(http::Method::POST)
                     .uri("/api/v1/accessions/raw")
-                    .header(
-                        http::header::CONTENT_TYPE,
-                        "multipart/form-data; boundary=------------------------abcdef1234567890",
-                    )
-                    .body(body)
+                    .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
+                    .body(Body::from(serde_json::to_vec(&metadata).unwrap()))
                     .unwrap(),
             )
             .await
@@ -889,19 +816,15 @@ mod tests {
             "original_url": "https://coolurl.com",
             "s3_filename": "test-small.wacz"
         });
-        let body = build_multipart_form_data(metadata, vec![], "", "", true).await;
 
         let response = app
             .oneshot(
                 Request::builder()
                     .method(http::Method::POST)
                     .uri("/api/v1/accessions/raw")
-                    .header(
-                        http::header::CONTENT_TYPE,
-                        "multipart/form-data; boundary=------------------------abcdef1234567890",
-                    )
+                    .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
                     .header(http::header::COOKIE, format!("jwt={}", get_mock_jwt()))
-                    .body(body)
+                    .body(Body::from(serde_json::to_vec(&metadata).unwrap()))
                     .unwrap(),
             )
             .await
@@ -928,19 +851,15 @@ mod tests {
             "original_url": "https://coolurl.com",
             "s3_filename": "test-large.wacz"
         });
-        let body = build_multipart_form_data(metadata, vec![], "", "", true).await;
 
         let response = app
             .oneshot(
                 Request::builder()
                     .method(http::Method::POST)
                     .uri("/api/v1/accessions/raw")
-                    .header(
-                        http::header::CONTENT_TYPE,
-                        "multipart/form-data; boundary=------------------------abcdef1234567890",
-                    )
+                    .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
                     .header(http::header::COOKIE, format!("jwt={}", get_mock_jwt()))
-                    .body(body)
+                    .body(Body::from(serde_json::to_vec(&metadata).unwrap()))
                     .unwrap(),
             )
             .await
@@ -967,37 +886,21 @@ mod tests {
             "original_url": "https://coolurl.com",
             "s3_filename": "test-invalid-metadata.wacz"
         });
-        let file_bytes = vec![0; 100]; // 100 bytes file
-        let body = build_multipart_form_data(
-            metadata,
-            file_bytes,
-            "invalid-metadata-file.wacz",
-            "application/wacz",
-            true,
-        )
-        .await;
 
         let response = app
             .oneshot(
                 Request::builder()
                     .method(http::Method::POST)
                     .uri("/api/v1/accessions/raw")
-                    .header(
-                        http::header::CONTENT_TYPE,
-                        "multipart/form-data; boundary=------------------------abcdef1234567890",
-                    )
+                    .header(http::header::CONTENT_TYPE, mime::APPLICATION_JSON.as_ref())
                     .header(http::header::COOKIE, format!("jwt={}", get_mock_jwt()))
-                    .body(body)
+                    .body(Body::from(serde_json::to_vec(&metadata).unwrap()))
                     .unwrap(),
             )
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        let body = response.into_body().collect().await.unwrap().to_bytes();
-        let actual = String::from_utf8((&body).to_vec()).unwrap();
-        assert!(actual
-            .contains("Failed to parse metadata JSON: Error(\"missing field `metadata_title`\""));
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
     }
 
     #[tokio::test]

--- a/src/services/accessions_service.rs
+++ b/src/services/accessions_service.rs
@@ -21,8 +21,6 @@ use crate::services::creators_service::CreatorsService;
 use crate::services::locations_service::LocationsService;
 use crate::services::subjects_service::SubjectsService;
 use ::entity::accessions_with_metadata::Model as AccessionWithMetadataModel;
-use axum::extract::multipart::Field;
-use axum::extract::Multipart;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
@@ -41,13 +39,6 @@ use validator::Validate;
 // using this to support streaming uploads of files that are slightly over 5MB, which will be the majority of uploads
 // to the archive
 static FIVE_MB: usize = 5 * 1024 * 1024;
-
-#[allow(dead_code)]
-#[derive(PartialEq, Eq)]
-enum MultiPartExtractionStep {
-    ExpectMetadata,
-    ExpectFile,
-}
 
 pub(crate) struct MetadataValidationParams {
     pub(crate) subjects: Vec<i32>,
@@ -272,6 +263,7 @@ impl AccessionsService {
                                     error!("Error occurred uploading WACZ file to S3: {:?}, aborting accession creation", err);
                                     return;
                                 };
+                                
                                 info!("WACZ file uploaded to S3 with filename {}", unique_filename);
                                 let create_accessions_request = CreateAccessionRequest {
                                     url: payload.url.clone(),
@@ -442,99 +434,6 @@ impl AccessionsService {
         }
     }
 
-    /// Writes a raw accession record (file-based, no crawl).
-    ///
-    /// # Arguments
-    /// * `payload` - The raw accession request with metadata and S3 filename
-    ///
-    /// # Returns
-    /// Result containing the accession ID or an error response
-    #[allow(dead_code)]
-    pub async fn write_one_raw(self, payload: CreateAccessionRequestRaw) -> Result<i32, Response> {
-        info!(
-            "Writing raw accession with title: {}",
-            payload.metadata_title
-        );
-        let write_result = self.accessions_repo.write_one_raw(payload).await;
-        match write_result {
-            Err(err) => {
-                error!(%err, "Error occurred writing raw accession to db");
-                Err((StatusCode::INTERNAL_SERVER_ERROR, "Internal database error").into_response())
-            }
-            Ok(id) => {
-                info!("Raw accession written to db successfully with id {id}");
-                Ok(id)
-            }
-        }
-    }
-
-    /// Extracts metadata from multipart form (without processing file).
-    ///
-    /// # Arguments
-    /// * `multipart` - The multipart form data from the HTTP request
-    ///
-    /// # Returns
-    /// Result containing the parsed accession request or an HTTP error response
-    pub async fn extract_accession_metadata_from_multipart(
-        self,
-        mut multipart: Multipart,
-    ) -> Result<CreateAccessionRequestRaw, Response> {
-        let mut metadata_payload: Option<CreateAccessionRequestRaw> = None;
-
-        while let Some(field) = multipart.next_field().await.map_err(|e| {
-            error!("Failed to read multipart field: {e:?}");
-            (StatusCode::BAD_REQUEST, "Malformed multipart request").into_response()
-        })? {
-            let field_name = field.name().unwrap_or("unknown").to_owned();
-
-            if field_name != "metadata" {
-                return Err((
-                    StatusCode::BAD_REQUEST,
-                    "Metadata field should be the first and only form field",
-                )
-                    .into_response());
-            }
-
-            let text = field.text().await.map_err(|e| {
-                error!("Failed to read metadata text: {e:?}");
-                (StatusCode::BAD_REQUEST, "Unable to read metadata field").into_response()
-            })?;
-
-            let parsed: CreateAccessionRequestRaw = serde_json::from_str(&text).map_err(|e| {
-                let error_msg = format!("Failed to parse metadata JSON: {e:?}");
-                error!(error_msg);
-                (StatusCode::BAD_REQUEST, error_msg).into_response()
-            })?;
-
-            if let Err(v_err) = parsed.validate() {
-                warn!("Invalid create accession request payload: {v_err:?}");
-                return Err((StatusCode::BAD_REQUEST, v_err.to_string()).into_response());
-            }
-
-            info!("Extracted and validated metadata JSON");
-            self.clone()
-                .validate_metadata_references(MetadataValidationParams {
-                    subjects: parsed.metadata_subjects.clone(),
-                    metadata_language: parsed.metadata_language,
-                    metadata_location_id: parsed.metadata_location_id,
-                    metadata_creator_id: parsed.metadata_creator_id,
-                    metadata_contributor_ids: parsed.metadata_contributor_ids.clone(),
-                    metadata_contributor_role_ids: parsed.metadata_contributor_role_ids.clone(),
-                })
-                .await?;
-
-            metadata_payload = Some(parsed);
-        }
-
-        metadata_payload.ok_or_else(|| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Could not extract metadata",
-            )
-                .into_response()
-        })
-    }
-
     /// Initiates a raw file upload by creating a placeholder in S3 and returning a presigned PUT URL.
     ///
     /// # Arguments
@@ -612,6 +511,159 @@ impl AccessionsService {
         }
     }
 
+    pub async fn validate_metadata_references(
+        self,
+        params: MetadataValidationParams,
+    ) -> Result<(), Response> {
+        if !params.subjects.is_empty() {
+            let subjects_exist = self
+                .subjects_service
+                .clone()
+                .verify_subjects_exist(params.subjects, params.metadata_language)
+                .await;
+            match subjects_exist {
+                Err(err) => {
+                    return Err(
+                        (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response()
+                    );
+                }
+                Ok(flag) => {
+                    if !flag {
+                        return Err(
+                            (StatusCode::BAD_REQUEST, "Subjects do not exist").into_response()
+                        );
+                    }
+                }
+            }
+        }
+
+        let mut location_ids: Vec<i32> = vec![];
+        if let Some(id) = params.metadata_location_id {
+            location_ids.push(id);
+        }
+        if !location_ids.is_empty() {
+            let locations_exist = self
+                .locations_service
+                .clone()
+                .verify_locations_exist(location_ids, params.metadata_language)
+                .await;
+            match locations_exist {
+                Err(err) => {
+                    return Err(
+                        (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response()
+                    );
+                }
+                Ok(flag) => {
+                    if !flag {
+                        return Err(
+                            (StatusCode::BAD_REQUEST, "Locations do not exist").into_response()
+                        );
+                    }
+                }
+            }
+        }
+
+        let mut creator_ids: Vec<i32> = vec![];
+        if let Some(id) = params.metadata_creator_id {
+            creator_ids.push(id);
+        }
+        if !creator_ids.is_empty() {
+            let creators_exist = self
+                .creators_service
+                .clone()
+                .verify_creators_exist(creator_ids, params.metadata_language)
+                .await;
+            match creators_exist {
+                Err(err) => {
+                    return Err(
+                        (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response()
+                    );
+                }
+                Ok(flag) => {
+                    if !flag {
+                        return Err(
+                            (StatusCode::BAD_REQUEST, "Creators do not exist").into_response()
+                        );
+                    }
+                }
+            }
+        }
+
+        if !params.metadata_contributor_ids.is_empty()
+            && params.metadata_contributor_ids.len() != params.metadata_contributor_role_ids.len()
+        {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "Contributor IDs and role IDs must have the same length",
+            )
+                .into_response());
+        }
+
+        let contributor_ids: Vec<i32> = params.metadata_contributor_ids.clone();
+        let role_ids: Vec<i32> = params
+            .metadata_contributor_role_ids
+            .iter()
+            .flatten()
+            .copied()
+            .collect();
+
+        if !contributor_ids.is_empty() {
+            let contributors_exist = self
+                .contributors_service
+                .clone()
+                .verify_contributors_exist(contributor_ids.clone(), params.metadata_language)
+                .await;
+            match contributors_exist {
+                Err(err) => {
+                    return Err(
+                        (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response()
+                    );
+                }
+                Ok(flag) => {
+                    if !flag {
+                        return Err(
+                            (StatusCode::BAD_REQUEST, "Contributors do not exist").into_response()
+                        );
+                    }
+                }
+            }
+        }
+
+        if !role_ids.is_empty() {
+            let roles_exist = self
+                .contributors_service
+                .clone()
+                .verify_roles_exist(role_ids.clone(), params.metadata_language)
+                .await;
+            match roles_exist {
+                Err(err) => {
+                    return Err(
+                        (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response()
+                    );
+                }
+                Ok(flag) => {
+                    if !flag {
+                        return Err((StatusCode::BAD_REQUEST, "Contributor roles do not exist")
+                            .into_response());
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn get_dublin_metadata_id(
+        &self,
+        accession_id: i32,
+        metadata_language: MetadataLanguage,
+    ) -> Result<Option<i32>, Response> {
+        self.accessions_repo
+            .get_dublin_metadata_id(accession_id, metadata_language)
+            .await
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response())
+    }
+
     /// Uploads from a generic stream to S3 with smart chunk handling.
     ///
     /// This method streams the bytes and decides on upload strategy as it reads:
@@ -625,7 +677,6 @@ impl AccessionsService {
     ///
     /// # Returns
     /// Result containing the upload ID or an error response
-    #[allow(dead_code)]
     async fn upload_from_stream<S, E>(
         self,
         key: String,
@@ -817,304 +868,5 @@ impl AccessionsService {
                 }
             }
         }
-    }
-
-    /// Uploads a file from a multipart field to S3 with smart chunk handling.
-    ///
-    /// This method streams the file and decides on upload strategy as it reads:
-    /// - Files under 5MB: buffered and uploaded with a single request
-    /// - Files over 5MB: multipart upload initiated and chunks streamed directly to S3
-    ///
-    /// # Arguments
-    /// * `key` - The S3 object key where the file will be uploaded
-    /// * `field` - The multipart field containing the file data
-    /// * `content_type` - The MIME type of the file
-    ///
-    /// # Returns
-    /// Result containing the upload ID or an error response
-    #[allow(dead_code)]
-    async fn upload_from_multipart_field(
-        self,
-        key: String,
-        field: Field<'_>,
-        content_type: String,
-    ) -> Result<String, Response> {
-        self.upload_from_stream(key, field, content_type).await
-    }
-
-    pub async fn validate_metadata_references(
-        self,
-        params: MetadataValidationParams,
-    ) -> Result<(), Response> {
-        if !params.subjects.is_empty() {
-            let subjects_exist = self
-                .subjects_service
-                .clone()
-                .verify_subjects_exist(params.subjects, params.metadata_language)
-                .await;
-            match subjects_exist {
-                Err(err) => {
-                    return Err(
-                        (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response()
-                    );
-                }
-                Ok(flag) => {
-                    if !flag {
-                        return Err(
-                            (StatusCode::BAD_REQUEST, "Subjects do not exist").into_response()
-                        );
-                    }
-                }
-            }
-        }
-
-        let mut location_ids: Vec<i32> = vec![];
-        if let Some(id) = params.metadata_location_id {
-            location_ids.push(id);
-        }
-        if !location_ids.is_empty() {
-            let locations_exist = self
-                .locations_service
-                .clone()
-                .verify_locations_exist(location_ids, params.metadata_language)
-                .await;
-            match locations_exist {
-                Err(err) => {
-                    return Err(
-                        (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response()
-                    );
-                }
-                Ok(flag) => {
-                    if !flag {
-                        return Err(
-                            (StatusCode::BAD_REQUEST, "Locations do not exist").into_response()
-                        );
-                    }
-                }
-            }
-        }
-
-        let mut creator_ids: Vec<i32> = vec![];
-        if let Some(id) = params.metadata_creator_id {
-            creator_ids.push(id);
-        }
-        if !creator_ids.is_empty() {
-            let creators_exist = self
-                .creators_service
-                .clone()
-                .verify_creators_exist(creator_ids, params.metadata_language)
-                .await;
-            match creators_exist {
-                Err(err) => {
-                    return Err(
-                        (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response()
-                    );
-                }
-                Ok(flag) => {
-                    if !flag {
-                        return Err(
-                            (StatusCode::BAD_REQUEST, "Creators do not exist").into_response()
-                        );
-                    }
-                }
-            }
-        }
-
-        if !params.metadata_contributor_ids.is_empty()
-            && params.metadata_contributor_ids.len() != params.metadata_contributor_role_ids.len()
-        {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                "Contributor IDs and role IDs must have the same length",
-            )
-                .into_response());
-        }
-
-        let contributor_ids: Vec<i32> = params.metadata_contributor_ids.clone();
-        let role_ids: Vec<i32> = params
-            .metadata_contributor_role_ids
-            .iter()
-            .flatten()
-            .copied()
-            .collect();
-
-        if !contributor_ids.is_empty() {
-            let contributors_exist = self
-                .contributors_service
-                .clone()
-                .verify_contributors_exist(contributor_ids.clone(), params.metadata_language)
-                .await;
-            match contributors_exist {
-                Err(err) => {
-                    return Err(
-                        (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response()
-                    );
-                }
-                Ok(flag) => {
-                    if !flag {
-                        return Err(
-                            (StatusCode::BAD_REQUEST, "Contributors do not exist").into_response()
-                        );
-                    }
-                }
-            }
-        }
-
-        if !role_ids.is_empty() {
-            let roles_exist = self
-                .contributors_service
-                .clone()
-                .verify_roles_exist(role_ids.clone(), params.metadata_language)
-                .await;
-            match roles_exist {
-                Err(err) => {
-                    return Err(
-                        (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response()
-                    );
-                }
-                Ok(flag) => {
-                    if !flag {
-                        return Err((StatusCode::BAD_REQUEST, "Contributor roles do not exist")
-                            .into_response());
-                    }
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Extracts and validates accession data from a multipart form submission.
-    ///
-    /// This method processes a multipart form containing metadata JSON and an optional file upload.
-    /// It validates the metadata, checks subject existence, uploads files to S3, and returns a
-    /// complete CreateAccessionRequestRaw object ready for database storage.
-    ///
-    /// The multipart form must have:
-    /// - First field: "metadata" containing JSON with accession metadata
-    /// - Optional subsequent fields: file uploads with filenames
-    ///
-    /// # Arguments
-    /// * `multipart` - The multipart form data from the HTTP request
-    /// * `subjects_service` - Service for validating metadata subjects exist
-    ///
-    /// # Returns
-    /// Result containing the parsed accession request or an HTTP error response
-    #[allow(dead_code)]
-    pub async fn extract_accession_from_multipart_form(
-        self,
-        mut multipart: Multipart,
-    ) -> Result<CreateAccessionRequestRaw, Response> {
-        let mut metadata_payload: Option<CreateAccessionRequestRaw> = None;
-        let mut step = MultiPartExtractionStep::ExpectMetadata; // first field must be the metadata JSON
-
-        while let Some(field) = multipart.next_field().await.map_err(|e| {
-            error!("Failed to read multipart field: {e:?}");
-            (StatusCode::BAD_REQUEST, "Malformed multipart request").into_response()
-        })? {
-            let field_name = field.name().unwrap_or("unknown").to_owned();
-            let filename_opt = field.file_name().map(str::to_owned);
-            let content_type = field
-                .content_type()
-                .map(str::to_owned)
-                .unwrap_or_else(|| "application/octet-stream".to_string());
-
-            info!(
-                "Processing multipart field: name={:?}, filename={:?}, content_type={:?}",
-                field_name, filename_opt, content_type
-            );
-
-            if step == MultiPartExtractionStep::ExpectMetadata {
-                if field_name != "metadata" {
-                    return Err((
-                        StatusCode::BAD_REQUEST,
-                        "Metadata field should be the first form field",
-                    )
-                        .into_response());
-                }
-
-                let text = field.text().await.map_err(|e| {
-                    error!("Failed to read metadata text: {e:?}");
-                    (StatusCode::BAD_REQUEST, "Unable to read metadata field").into_response()
-                })?;
-
-                let parsed: CreateAccessionRequestRaw =
-                    serde_json::from_str(&text).map_err(|e| {
-                        let error_msg = format!("Failed to parse metadata JSON: {e:?}");
-                        error!(error_msg);
-                        (StatusCode::BAD_REQUEST, error_msg).into_response()
-                    })?;
-
-                if let Err(v_err) = parsed.validate() {
-                    warn!("Invalid create accession request payload: {v_err:?}");
-                    return Err((StatusCode::BAD_REQUEST, v_err.to_string()).into_response());
-                }
-
-                info!("Extracted and validated metadata JSON");
-                self.clone()
-                    .validate_metadata_references(MetadataValidationParams {
-                        subjects: parsed.metadata_subjects.clone(),
-                        metadata_language: parsed.metadata_language,
-                        metadata_location_id: parsed.metadata_location_id,
-                        metadata_creator_id: parsed.metadata_creator_id,
-                        metadata_contributor_ids: parsed.metadata_contributor_ids.clone(),
-                        metadata_contributor_role_ids: parsed.metadata_contributor_role_ids.clone(),
-                    })
-                    .await?;
-
-                metadata_payload = Some(parsed);
-                step = MultiPartExtractionStep::ExpectFile;
-                continue;
-            }
-
-            if filename_opt.is_some() {
-                let create_request = metadata_payload.as_mut().ok_or_else(|| {
-                    (StatusCode::BAD_REQUEST, "File part arrived before metadata").into_response()
-                })?;
-
-                let file_ext = match create_request.metadata_format {
-                    DublinMetadataFormat::Wacz => "wacz",
-                };
-
-                // Discard the original filename since we have all that from the metadata
-                // Use this to make sure there are no filename collisions between objects in s3
-                let unique_name = format!("{}.{}", Uuid::new_v4(), file_ext);
-                create_request.s3_filename = unique_name.clone();
-                self.clone()
-                    .upload_from_multipart_field(unique_name.clone(), field, content_type.clone())
-                    .await
-                    .map_err(|e| {
-                        error!("Failed to upload file {unique_name}: {e:?}");
-                        e
-                    })?;
-
-                info!("Successfully uploaded file: {unique_name}");
-                if let Some(ref mut req) = metadata_payload {
-                    req.s3_filename = unique_name;
-                }
-                continue;
-            }
-
-            error!("Skipping unexpected field without filename: name={field_name}");
-        }
-
-        metadata_payload.ok_or_else(|| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Could not extract metadata",
-            )
-                .into_response()
-        })
-    }
-
-    pub async fn get_dublin_metadata_id(
-        &self,
-        accession_id: i32,
-        metadata_language: MetadataLanguage,
-    ) -> Result<Option<i32>, Response> {
-        self.accessions_repo
-            .get_dublin_metadata_id(accession_id, metadata_language)
-            .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response())
     }
 }

--- a/src/services/accessions_service.rs
+++ b/src/services/accessions_service.rs
@@ -8,7 +8,9 @@ use crate::models::request::AccessionPaginationWithPrivate;
 use crate::models::request::{
     CreateAccessionRequest, CreateAccessionRequestRaw, CreateCrawlRequest, UpdateAccessionRequest,
 };
-use crate::models::response::{GetOneAccessionResponse, ListAccessionsResponse};
+use crate::models::response::{
+    GetOneAccessionResponse, InitiateUploadResponse, ListAccessionsResponse,
+};
 use crate::repos::accessions_repo::AccessionsRepo;
 use crate::repos::auth_repo::AuthRepo;
 use crate::repos::browsertrix_repo::BrowsertrixRepo;
@@ -40,6 +42,7 @@ use validator::Validate;
 // to the archive
 static FIVE_MB: usize = 5 * 1024 * 1024;
 
+#[allow(dead_code)]
 #[derive(PartialEq, Eq)]
 enum MultiPartExtractionStep {
     ExpectMetadata,
@@ -68,6 +71,7 @@ pub struct AccessionsService {
     pub locations_service: LocationsService,
     pub creators_service: CreatorsService,
     pub contributors_service: ContributorsService,
+    pub presigned_put_url_expiry_seconds: u64,
 }
 
 impl AccessionsService {
@@ -445,6 +449,7 @@ impl AccessionsService {
     ///
     /// # Returns
     /// Result containing the accession ID or an error response
+    #[allow(dead_code)]
     pub async fn write_one_raw(self, payload: CreateAccessionRequestRaw) -> Result<i32, Response> {
         info!(
             "Writing raw accession with title: {}",
@@ -463,6 +468,150 @@ impl AccessionsService {
         }
     }
 
+    /// Extracts metadata from multipart form (without processing file).
+    ///
+    /// # Arguments
+    /// * `multipart` - The multipart form data from the HTTP request
+    ///
+    /// # Returns
+    /// Result containing the parsed accession request or an HTTP error response
+    pub async fn extract_accession_metadata_from_multipart(
+        self,
+        mut multipart: Multipart,
+    ) -> Result<CreateAccessionRequestRaw, Response> {
+        let mut metadata_payload: Option<CreateAccessionRequestRaw> = None;
+
+        while let Some(field) = multipart.next_field().await.map_err(|e| {
+            error!("Failed to read multipart field: {e:?}");
+            (StatusCode::BAD_REQUEST, "Malformed multipart request").into_response()
+        })? {
+            let field_name = field.name().unwrap_or("unknown").to_owned();
+
+            if field_name != "metadata" {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    "Metadata field should be the first and only form field",
+                )
+                    .into_response());
+            }
+
+            let text = field.text().await.map_err(|e| {
+                error!("Failed to read metadata text: {e:?}");
+                (StatusCode::BAD_REQUEST, "Unable to read metadata field").into_response()
+            })?;
+
+            let parsed: CreateAccessionRequestRaw = serde_json::from_str(&text).map_err(|e| {
+                let error_msg = format!("Failed to parse metadata JSON: {e:?}");
+                error!(error_msg);
+                (StatusCode::BAD_REQUEST, error_msg).into_response()
+            })?;
+
+            if let Err(v_err) = parsed.validate() {
+                warn!("Invalid create accession request payload: {v_err:?}");
+                return Err((StatusCode::BAD_REQUEST, v_err.to_string()).into_response());
+            }
+
+            info!("Extracted and validated metadata JSON");
+            self.clone()
+                .validate_metadata_references(MetadataValidationParams {
+                    subjects: parsed.metadata_subjects.clone(),
+                    metadata_language: parsed.metadata_language,
+                    metadata_location_id: parsed.metadata_location_id,
+                    metadata_creator_id: parsed.metadata_creator_id,
+                    metadata_contributor_ids: parsed.metadata_contributor_ids.clone(),
+                    metadata_contributor_role_ids: parsed.metadata_contributor_role_ids.clone(),
+                })
+                .await?;
+
+            metadata_payload = Some(parsed);
+        }
+
+        metadata_payload.ok_or_else(|| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Could not extract metadata",
+            )
+                .into_response()
+        })
+    }
+
+    /// Initiates a raw file upload by creating a placeholder in S3 and returning a presigned PUT URL.
+    ///
+    /// # Arguments
+    /// * `payload` - The raw accession request with metadata (minus the file)
+    ///
+    /// # Returns
+    /// JSON response containing accession ID and presigned upload URL
+    pub async fn initiate_raw_upload(self, mut payload: CreateAccessionRequestRaw) -> Response {
+        let file_ext = match payload.metadata_format {
+            DublinMetadataFormat::Wacz => "wacz",
+        };
+
+        let unique_filename = format!("{}.{}", Uuid::new_v4(), file_ext);
+        payload.s3_filename = unique_filename.clone();
+
+        info!("Creating placeholder in S3: {}", unique_filename);
+
+        let placeholder_content = Bytes::new();
+        match self
+            .s3_repo
+            .upload_from_bytes(
+                &unique_filename,
+                placeholder_content,
+                "application/octet-stream",
+            )
+            .await
+        {
+            Ok(_) => {
+                info!("Placeholder created in S3: {}", unique_filename);
+            }
+            Err(err) => {
+                error!(%err, "Failed to create placeholder in S3: {}", unique_filename);
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "Failed to create S3 placeholder",
+                )
+                    .into_response();
+            }
+        }
+
+        let upload_url = match self
+            .s3_repo
+            .generate_presigned_put_url(&unique_filename, self.presigned_put_url_expiry_seconds)
+            .await
+        {
+            Ok(url) => {
+                info!("Generated presigned PUT URL for: {}", unique_filename);
+                url
+            }
+            Err(e) => {
+                error!("Failed to generate presigned PUT URL: {}", e);
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "Failed to generate upload URL",
+                )
+                    .into_response();
+            }
+        };
+
+        let write_result = self.accessions_repo.write_one_raw(payload).await;
+        match write_result {
+            Err(err) => {
+                error!(%err, "Error occurred writing raw accession to db");
+                let _ = self.s3_repo.delete_object(&unique_filename).await;
+                (StatusCode::INTERNAL_SERVER_ERROR, "Internal database error").into_response()
+            }
+            Ok(id) => {
+                info!("Raw accession written to db successfully with id {id}");
+                let response = InitiateUploadResponse {
+                    accession_id: id,
+                    upload_url,
+                };
+                (StatusCode::CREATED, Json(response)).into_response()
+            }
+        }
+    }
+
     /// Uploads from a generic stream to S3 with smart chunk handling.
     ///
     /// This method streams the bytes and decides on upload strategy as it reads:
@@ -476,6 +625,7 @@ impl AccessionsService {
     ///
     /// # Returns
     /// Result containing the upload ID or an error response
+    #[allow(dead_code)]
     async fn upload_from_stream<S, E>(
         self,
         key: String,
@@ -682,6 +832,7 @@ impl AccessionsService {
     ///
     /// # Returns
     /// Result containing the upload ID or an error response
+    #[allow(dead_code)]
     async fn upload_from_multipart_field(
         self,
         key: String,
@@ -849,6 +1000,7 @@ impl AccessionsService {
     ///
     /// # Returns
     /// Result containing the parsed accession request or an HTTP error response
+    #[allow(dead_code)]
     pub async fn extract_accession_from_multipart_form(
         self,
         mut multipart: Multipart,

--- a/src/services/accessions_service.rs
+++ b/src/services/accessions_service.rs
@@ -32,7 +32,6 @@ use std::time::Duration;
 use tokio::time::sleep;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
-use validator::Validate;
 
 // Using this as the min part size for multipart uploads to S3. This is low since this code is designed to run in
 // a very low memory container environment. Plus we don't want to allow too large uploads anyway, so we are mostly
@@ -263,7 +262,7 @@ impl AccessionsService {
                                     error!("Error occurred uploading WACZ file to S3: {:?}, aborting accession creation", err);
                                     return;
                                 };
-                                
+
                                 info!("WACZ file uploaded to S3 with filename {}", unique_filename);
                                 let create_accessions_request = CreateAccessionRequest {
                                     url: payload.url.clone(),
@@ -422,6 +421,21 @@ impl AccessionsService {
                 .into_response();
         }
 
+        if let Err(response) = self
+            .clone()
+            .validate_metadata_references(MetadataValidationParams {
+                subjects: payload.metadata_subjects.clone(),
+                metadata_language: payload.metadata_language,
+                metadata_location_id: payload.metadata_location_id,
+                metadata_creator_id: payload.metadata_creator_id,
+                metadata_contributor_ids: payload.metadata_contributor_ids.clone(),
+                metadata_contributor_role_ids: payload.metadata_contributor_role_ids.clone(),
+            })
+            .await
+        {
+            return response;
+        }
+
         let is_private = payload.is_private;
         let update_result = self.accessions_repo.update_one(id, payload).await;
         match update_result {
@@ -442,6 +456,21 @@ impl AccessionsService {
     /// # Returns
     /// JSON response containing accession ID and presigned upload URL
     pub async fn initiate_raw_upload(self, mut payload: CreateAccessionRequestRaw) -> Response {
+        if let Err(response) = self
+            .clone()
+            .validate_metadata_references(MetadataValidationParams {
+                subjects: payload.metadata_subjects.clone(),
+                metadata_language: payload.metadata_language,
+                metadata_location_id: payload.metadata_location_id,
+                metadata_creator_id: payload.metadata_creator_id,
+                metadata_contributor_ids: payload.metadata_contributor_ids.clone(),
+                metadata_contributor_role_ids: payload.metadata_contributor_role_ids.clone(),
+            })
+            .await
+        {
+            return response;
+        }
+
         let file_ext = match payload.metadata_format {
             DublinMetadataFormat::Wacz => "wacz",
         };

--- a/src/test_tools.rs
+++ b/src/test_tools.rs
@@ -898,6 +898,14 @@ impl S3Repo for InMemoryS3Repo {
         Ok("my url".to_string())
     }
 
+    async fn generate_presigned_put_url(
+        &self,
+        _object_key: &str,
+        _expires_in: u64,
+    ) -> Result<String, Box<dyn StdError>> {
+        Ok("https://test-bucket.s3.example.com/mock-presigned-put-url".to_string())
+    }
+
     async fn initiate_multipart_upload(
         &self,
         key: &str,
@@ -953,6 +961,7 @@ pub fn build_test_accessions_service() -> AccessionsService {
         locations_service,
         creators_service,
         contributors_service,
+        presigned_put_url_expiry_seconds: 900,
     }
 }
 


### PR DESCRIPTION
Breaking change: POST /accessions/raw now expects metadata-only multipart and returns a presigned S3 PUT URL. Client uploads directly to S3 instead of streaming through the API, bypassing the 100s load balancer timeout.

Changes: API creates empty placeholder in S3, returns presigned PUT URL (15min expiry via PRESIGNED_PUT_URL_EXPIRY_SECONDS env var), client uploads directly. Response format changed from text to JSON with {accession_id, upload_url}. Removed streaming upload complexity from accessions_ervice. No longer supports file in multipart upload.